### PR TITLE
Add unit declarator to role declarations

### DIFF
--- a/lib/PerlStore/FileStore.pm6
+++ b/lib/PerlStore/FileStore.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-role FileStore;
+unit role FileStore;
 
 sub serialize($what) returns Str {
     $what.perl


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.
