### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,12 +1,15 @@
 {
-    "perl"        : "6.*",
-    "name"        : "PerlStore",
-    "version"     : "*",
-    "author"	  : "github:teodozjan",
-    "description" : "Implemented simple Serialization form http://doc.perl6.org",
-    "depends"     : [ ],
-    "provides"    : {
-	        "PerlStore::FileStore" : "lib/PerlStore/FileStore.pm6"
-	 },
-    "source-url"  : "git://github.com/teodozjan/perl-store.git"
+  "name": "PerlStore",
+  "source-url": "git://github.com/teodozjan/perl-store.git",
+  "perl": "6.*",
+  "author": "github:teodozjan",
+  "depends": [
+    
+  ],
+  "license": "Artistic-2.0",
+  "provides": {
+    "PerlStore::FileStore": "lib/PerlStore/FileStore.pm6"
+  },
+  "version": "*",
+  "description": "Implemented simple Serialization form http://doc.perl6.org"
 }


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license